### PR TITLE
Fix warnings due to removed parameters

### DIFF
--- a/src/LeastSquares.jl
+++ b/src/LeastSquares.jl
@@ -60,9 +60,15 @@ function prepareRegularization(reg::Vector{R}, regLS::LeastSquaresParameters) wh
 
   # Add further constraints
   if params.enforceReal && params.enforcePositive
-    push!(result, PositiveRegularization())
+    if !any([item isa PositiveRegularization for item ∈ reg])
+      push!(result, PositiveRegularization())
+    end
+
+    filter!(x -> !(x isa RealRegularization), reg)
   elseif params.enforceReal
-    push!(result, RealRegularization())
+    if !any([item isa RealRegularization for item ∈ reg])
+      push!(result, RealRegularization())
+    end
   end
 
   pop!(args, :enforceReal)

--- a/src/LeastSquares.jl
+++ b/src/LeastSquares.jl
@@ -3,12 +3,13 @@ export LeastSquaresParameters
 abstract type AbstractSolverParameters <: AbstractMPIRecoParameters end
 
 export LeastSquaresParameters
-Base.@kwdef struct LeastSquaresParameters{L<:AbstractLinearSolver, O, M, R<:AbstractRegularization, P<:AbstractSolverParameters} <: AbstractMPIRecoParameters
+Base.@kwdef struct LeastSquaresParameters{L<:AbstractLinearSolver, O, M, R<:AbstractRegularization, P<:AbstractSolverParameters, W} <: AbstractMPIRecoParameters
   solver::Type{L} = Kaczmarz
   op::O = nothing
   S::M
   reg::Vector{R} 
   solverParams::P
+  weights::W = nothing
 end
 
 # TODO place weights and more
@@ -37,7 +38,7 @@ function process(t::Type{<:AbstractMPIRecoAlgorithm}, params::LeastSquaresParame
   reg, args = prepareRegularization(params.reg, params)
   args[:reg] = reg
 
-  solv = createLinearSolver(params.solver, params.S; args...)
+  solv = createLinearSolver(params.solver, params.S; args..., weights = params.weights)
 
   for l=1:L
     d = solve!(solv, u[:, l])


### PR DESCRIPTION
The Kazcmarz does also yield a warning since it does not accept the parameter `weights`. Is this intended or has that gone missing?