### PR TITLE
GPU support for sparse single patch and for multi patch reconstructions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,21 +17,21 @@ steps:
       include("test/gpu/cuda.jl")'
     timeout_in_minutes: 30
 
-  - label: "AMD GPUs -- MPIReco.jl"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.10"
-    agents:
-      queue: "juliagpu"
-      rocm: "*"
-      rocmgpu: "*"
-    command: |
-      julia --color=yes --project -e '
-      using Pkg
-      Pkg.add("TestEnv")
-      using TestEnv
-      TestEnv.activate();
-      Pkg.add("AMDGPU")
-      Pkg.instantiate()
-      include("test/gpu/rocm.jl")'
-    timeout_in_minutes: 30
+  # - label: "AMD GPUs -- MPIReco.jl"
+  #   plugins:
+  #     - JuliaCI/julia#v1:
+  #         version: "1.10"
+  #   agents:
+  #     queue: "juliagpu"
+  #     rocm: "*"
+  #     rocmgpu: "*"
+  #   command: |
+  #     julia --color=yes --project -e '
+  #     using Pkg
+  #     Pkg.add("TestEnv")
+  #     using TestEnv
+  #     TestEnv.activate();
+  #     Pkg.add("AMDGPU")
+  #     Pkg.instantiate()
+  #     include("test/gpu/rocm.jl")'
+  #   timeout_in_minutes: 30

--- a/Project.toml
+++ b/Project.toml
@@ -27,6 +27,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 AbstractImageReconstruction = "0.3"
 Adapt = "3, 4"
+Atomix = "0.1"
 DSP = "0.6, 0.7"
 Distributed = "1"
 DistributedArrays = "0.6"
@@ -61,6 +62,7 @@ ImageQualityIndexes = "2996bd0c-7a13-11e9-2da2-2f5ce47296a9"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [weakdeps]
+Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 
@@ -68,4 +70,4 @@ GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
 test = ["Test", "HTTP", "FileIO", "LazyArtifacts", "Scratch", "ImageMagick", "ImageQualityIndexes", "Unitful", "JLArrays"]
 
 [extensions]
-MPIRecoKernelAbstractionsExt = ["KernelAbstractions", "GPUArrays"]
+MPIRecoKernelAbstractionsExt = ["Atomix","KernelAbstractions", "GPUArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Tobias Knopp <tobias@knoppweb.de>"]
 version = "0.6.0"
 
 [deps]
+Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 DistributedArrays = "aaf54ef3-cdf8-58ed-94cc-d582ad619b94"
@@ -25,6 +26,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 AbstractImageReconstruction = "0.3"
+Adapt = "3, 4"
 DSP = "0.6, 0.7"
 Distributed = "1"
 DistributedArrays = "0.6"

--- a/Project.toml
+++ b/Project.toml
@@ -31,9 +31,11 @@ DSP = "0.6, 0.7"
 Distributed = "1"
 DistributedArrays = "0.6"
 FFTW = "1.3"
+GPUArrays = "8, 9, 10"
 ImageUtils = "0.2"
 IniFile = "0.5"
 JLArrays = "0.1"
+KernelAbstractions = "0.8, 0.9"
 LinearAlgebra = "1"
 LinearOperators = "2.3"
 LinearOperatorCollection = "2"
@@ -58,5 +60,12 @@ ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 ImageQualityIndexes = "2996bd0c-7a13-11e9-2da2-2f5ce47296a9"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
+[weakdeps]
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
+GPUArrays = "0c68f7d7-f131-5f86-a1c3-88cf8149b2d7"
+
 [targets]
 test = ["Test", "HTTP", "FileIO", "LazyArtifacts", "Scratch", "ImageMagick", "ImageQualityIndexes", "Unitful", "JLArrays"]
+
+[extensions]
+MPIRecoKernelAbstractionsExt = ["KernelAbstractions", "GPUArrays"]

--- a/config/MultiPatch.toml
+++ b/config/MultiPatch.toml
@@ -26,7 +26,7 @@ _module = "MPIReco"
         _module = "MPIReco"
 
         [parameter.reco.solverParams]
-        _type = "RecoPlan{SimpleSolverParameters}"
+        _type = "RecoPlan{ElaborateSolverParameters}"
         _module = "MPIReco"
 
     [parameter.pre]

--- a/ext/MPIRecoKernelAbstractionsExt/MPIRecoKernelAbstractionsExt.jl
+++ b/ext/MPIRecoKernelAbstractionsExt/MPIRecoKernelAbstractionsExt.jl
@@ -1,0 +1,8 @@
+module MPIRecoKernelAbstractionsExt 
+
+using MPIReco, MPIReco.Adapt, MPIReco.LinearAlgebra
+using KernelAbstractions, GPUArrays
+
+include("MultiPatch.jl")
+
+end

--- a/ext/MPIRecoKernelAbstractionsExt/MPIRecoKernelAbstractionsExt.jl
+++ b/ext/MPIRecoKernelAbstractionsExt/MPIRecoKernelAbstractionsExt.jl
@@ -3,7 +3,7 @@ module MPIRecoKernelAbstractionsExt
 using MPIReco, MPIReco.Adapt, MPIReco.LinearAlgebra
 using KernelAbstractions, GPUArrays
 using KernelAbstractions.Extras: @unroll
-using KernelAbstractions.Atomix
+using Atomix
 
 include("MultiPatch.jl")
 

--- a/ext/MPIRecoKernelAbstractionsExt/MPIRecoKernelAbstractionsExt.jl
+++ b/ext/MPIRecoKernelAbstractionsExt/MPIRecoKernelAbstractionsExt.jl
@@ -1,6 +1,6 @@
 module MPIRecoKernelAbstractionsExt 
 
-using MPIReco, MPIReco.Adapt, MPIReco.LinearAlgebra
+using MPIReco, MPIReco.Adapt, MPIReco.LinearAlgebra, MPIReco.RegularizedLeastSquares
 using KernelAbstractions, GPUArrays
 using KernelAbstractions.Extras: @unroll
 using Atomix

--- a/ext/MPIRecoKernelAbstractionsExt/MPIRecoKernelAbstractionsExt.jl
+++ b/ext/MPIRecoKernelAbstractionsExt/MPIRecoKernelAbstractionsExt.jl
@@ -2,6 +2,7 @@ module MPIRecoKernelAbstractionsExt
 
 using MPIReco, MPIReco.Adapt, MPIReco.LinearAlgebra
 using KernelAbstractions, GPUArrays
+using KernelAbstractions.Extras: @unroll
 
 include("MultiPatch.jl")
 

--- a/ext/MPIRecoKernelAbstractionsExt/MPIRecoKernelAbstractionsExt.jl
+++ b/ext/MPIRecoKernelAbstractionsExt/MPIRecoKernelAbstractionsExt.jl
@@ -3,6 +3,7 @@ module MPIRecoKernelAbstractionsExt
 using MPIReco, MPIReco.Adapt, MPIReco.LinearAlgebra
 using KernelAbstractions, GPUArrays
 using KernelAbstractions.Extras: @unroll
+using KernelAbstractions.Atomix
 
 include("MultiPatch.jl")
 

--- a/ext/MPIRecoKernelAbstractionsExt/MultiPatch.jl
+++ b/ext/MPIRecoKernelAbstractionsExt/MultiPatch.jl
@@ -65,15 +65,15 @@ function LinearAlgebra.mul!(b::AbstractVector{T}, op::DenseMultiPatchOperator{T,
   return b
 end
 
-@kernel cpu = false function dense_mul_adj!(res, @Const(t), @Const(S), @Const(xcc), @Const(xss), @Const(signs), @Const(M), @Const(RowToPatch), @Const(patchToSMIdx))
+@kernel function dense_mul_adj!(res, @Const(t), @Const(S), @Const(xcc), @Const(xss), @Const(signs), @Const(M), @Const(RowToPatch), @Const(patchToSMIdx))
   # Each group/block handles a single column of the adjoint(operator)
   # i.e. a row of the operator
   localIdx = @index(Local, Linear)
   groupIdx = @index(Group, Linear) # k
   patch = RowToPatch[groupIdx] # p
-  patch_row = mod1(operator_row, M) # j
+  patch_row = mod1(groupIdx, M) # j
   smIdx = patchToSMIdx[patch]
-  sign = eltype(b)(signs[patch_row, smIdx])
+  sign = eltype(res)(signs[patch_row, smIdx])
   grid_stride = prod(@groupsize())
   N = size(xss, 1)
   
@@ -84,15 +84,19 @@ end
   # Since we go along the columns during a matrix-vector product,
   # we have a race condition with other threads writing to the same result.
   for i = localIdx:grid_stride:N
-    Atomix.@atomic res[xcc[i, patch]] += adjoint(sign * S[patch_row, xss[i, patch], smIdx]) * val
+    tmp = sign * adjoint(S[patch_row, xss[i, patch], smIdx]) * val
+    # @atomic is not supported for ComplexF32 numbers
+    Atomix.@atomic res[1, xcc[i, patch]] += tmp.re
+    Atomix.@atomic res[2, xcc[i, patch]] += tmp.im
   end
 end
 
-function LinearAlgebra.mul!(res::AbstractVector{T}, adj::Adjoint{T, OP}, t::AbstractVector{T}) where {T, V <: AbstractGPUArray, OP <: DenseMultiPatchOperator{T, V}}
+function LinearAlgebra.mul!(res::AbstractVector{T}, adj::Adjoint{T, OP}, t::AbstractVector{T}) where {T <: Complex, V <: AbstractArray, OP <: DenseMultiPatchOperator{T, V}}
   backend = get_backend(res)
   op = adj.parent
   kernel = dense_mul_adj!(backend, 256)
-  kernel(res, t, op.S, op.xcc, op.xss, op.sign, div(op.M, op.nPatches), op.RowToPatch, op.patchToSMIdx; ndrange = (256, size(op, 1)))
+  # We have to reinterpret the result as a real array, because atomic operations on Complex numbers are not supported
+  kernel(reinterpret(reshape, real(eltype(res)), res), t, op.S, op.xcc, op.xss, op.sign, div(op.M, op.nPatches), op.RowToPatch, op.patchToSMIdx; ndrange = (256, size(op, 1)))
   synchronize(backend)
   return res
 end

--- a/ext/MPIRecoKernelAbstractionsExt/MultiPatch.jl
+++ b/ext/MPIRecoKernelAbstractionsExt/MultiPatch.jl
@@ -84,7 +84,7 @@ end
   # Since we go along the columns during a matrix-vector product,
   # we have a race condition with other threads writing to the same result.
   for i = localIdx:grid_stride:N
-    Atomix.@atomic res[xcc[i, patch]] += sign * S[patch_row, xss[i, patch], smIdx] * val
+    Atomix.@atomic res[xcc[i, patch]] += adjoint(sign * S[patch_row, xss[i, patch], smIdx]) * val
   end
 end
 

--- a/ext/MPIRecoKernelAbstractionsExt/MultiPatch.jl
+++ b/ext/MPIRecoKernelAbstractionsExt/MultiPatch.jl
@@ -1,0 +1,69 @@
+function Adapt.adapt_structure(::Type{arrT}, op::MultiPatchOperator) where {arrT <: AbstractGPUArray}
+  validSMs = all(x -> size(x) == size(op.S[1]), op.S)
+  validXCC = all(x -> length(x) == length(op.xcc[1]), op.xcc)
+  validXSS = all(x -> length(x) == length(op.xss[1]), op.xss)
+
+  # Ideally we create a DenseMultiPatchOperator on the GPU
+  if validSMs && validXCC && validXSS
+    S = adapt(arrT, stack(op.S))
+    # We want to use Int32 for better GPU performance
+    xcc = Int32.(adapt(arrT, stack(op.xcc)))
+    xss = Int32.(adapt(arrT, stack(op.xss)))
+    sign = Int32.(adapt(arrT, op.sign))
+    RowToPatch = Int32.(adapt(arrT, op.RowToPatch))
+    patchToSMIdx = Int32.(adapt(arrT, op.patchToSMIdx))
+    return DenseMultiPatchOperator(S, op.grid, Int32(op.N), Int32(op.M), RowToPatch, xcc, xss, sign, Int32(op.nPatches), patchToSMIdx)
+  else
+    throw(ArgumentError("Cannot adapt MultiPatchOperator to $arrT, since it cannot be represented as a DenseMultiPatchOperator"))
+  end
+end
+
+@kernel function dense_mul!(b, @Const(x), @Const(S), @Const(xcc), @Const(xss), @Const(signs), @Const(M), @Const(RowToPatch), @Const(patchToSMIdx))
+  # Each group/block handles a single row of the operator
+  operator_row = @index(Group, Linear) # k
+  patch = RowToPatch[operator_row] # p
+  patch_row = mod1(operator_row, M) # j
+  smIdx = patchToSMIdx[patch]
+  sign = signs[patch_row, smIdx]
+  grid_stride = prod(@groupsize())
+  N = size(xss, 1)
+  
+  # We want to use a grid-stride loop to perform the sparse matrix-vector product.
+  # Each thread performs a single element-wise multiplication and reduction in its shared spot.
+  # Afterwards we reduce over the shared memory.
+  localIdx = @index(Local, Linear)
+  shared = @localmem eltype(b) prod(@groupsize())
+  shared[localIdx] = zero(eltype(b))
+
+  # First we iterate over the sparse indices
+  i = localIdx
+  while i <= N
+    shared[localIdx] = shared[localIdx] + sign * S[patch_row, xss[i, patch], smIdx] * x[xcc[i, patch]]
+    i += grid_stride
+  end
+  @synchronize
+
+  # Now we need to reduce the shared memory to get the final result
+  @private s = div(min(grid_stride, N), Int32(2))
+  while s > Int32(0)
+    if localIdx <= s
+      shared[localIdx] = shared[localIdx] + shared[localIdx + s]
+    end
+    s >>= 1
+    @synchronize
+  end
+
+  # Write the result out to b
+  if localIdx == 1
+    b[operator_row] = shared[localIdx]
+  end
+end
+
+function LinearAlgebra.mul!(b::AbstractVector{T}, op::DenseMultiPatchOperator{T, V}, x::AbstractVector{T}) where {T, V}
+  b[:] .= zero(T)
+  backend = get_backend(b)
+  kernel = dense_mul!(backend, 256)
+  kernel(b, x, op.S, op.xcc, op.xss, op.sign, div(op.M, op.nPatches), op.RowToPatch, op.patchToSMIdx; ndrange = (256, size(op, 1)))
+  synchronize(backend)
+  return b
+end

--- a/src/Algorithms/MultiPatchAlgorithms/MultiPatchPeriodicMotion.jl
+++ b/src/Algorithms/MultiPatchAlgorithms/MultiPatchPeriodicMotion.jl
@@ -24,7 +24,7 @@ end
 function MultiPatchReconstructionAlgorithm(params::MultiPatchParameters{<:PeriodicMotionPreProcessing,<:PeriodicMotionReconstructionParameter,<:AbstractMPIPostProcessingParameters})
   reco = params.reco
   freqs = process(MultiPatchReconstructionAlgorithm, reco.freqFilter, reco.sf)
-  return MultiPatchReconstructionAlgorithm(params, nothing, reco.sf, nothing, nothing, nothing, freqs, Channel{Any}(Inf))
+  return MultiPatchReconstructionAlgorithm(params, nothing, reco.sf, Array, nothing, nothing, nothing, freqs, Channel{Any}(Inf))
 end
 
 function AbstractImageReconstruction.put!(algo::MultiPatchReconstructionAlgorithm{MultiPatchParameters{PT, R, T}}, data::MPIFile) where {R, T, PT <: PeriodicMotionPreProcessing}

--- a/src/Algorithms/SinglePatchAlgorithms/SinglePatchAlgorithm.jl
+++ b/src/Algorithms/SinglePatchAlgorithms/SinglePatchAlgorithm.jl
@@ -1,19 +1,21 @@
 Base.@kwdef struct SinglePatchReconstructionParameter{L<:AbstractSystemMatrixLoadingParameter, SL<:AbstractLinearSolver,
-   SP<:AbstractSolverParameters{SL}, R<:AbstractRegularization, W<:AbstractWeightingParameters} <: AbstractSinglePatchReconstructionParameters
+   matT <: AbstractArray, SP<:AbstractSolverParameters{SL}, R<:AbstractRegularization, W<:AbstractWeightingParameters} <: AbstractSinglePatchReconstructionParameters
   # File
   sf::MPIFile
   sfLoad::Union{L, ProcessResultCache{L}}
+  arrayType::Type{matT} = Array
   # Solver
   solverParams::SP
   reg::Vector{R} = AbstractRegularization[]
   weightingParams::W = NoWeightingParameters()
 end
 
-Base.@kwdef mutable struct SinglePatchReconstructionAlgorithm{P} <: AbstractSinglePatchReconstructionAlgorithm where {P<:AbstractSinglePatchAlgorithmParameters}
+Base.@kwdef mutable struct SinglePatchReconstructionAlgorithm{P, matT <: AbstractArray} <: AbstractSinglePatchReconstructionAlgorithm where {P<:AbstractSinglePatchAlgorithmParameters}
   params::P
   # Could also do reconstruction progress meter here
   sf::Union{MPIFile, Vector{MPIFile}}
   S::AbstractArray
+  arrayType::Type{matT}
   grid::RegularGridPositions
   freqs::Vector{CartesianIndex{2}}
   output::Channel{Any}
@@ -23,16 +25,16 @@ function SinglePatchReconstruction(params::SinglePatchParameters{<:AbstractMPIPr
   return SinglePatchReconstructionAlgorithm(params)
 end
 function SinglePatchReconstructionAlgorithm(params::SinglePatchParameters{<:AbstractMPIPreProcessingParameters, R, PT}) where {R<:AbstractSinglePatchReconstructionParameters, PT <:AbstractMPIPostProcessingParameters}
-  freqs, S, grid = prepareSystemMatrix(params.reco)
-  return SinglePatchReconstructionAlgorithm(params, params.reco.sf, S, grid, freqs, Channel{Any}(Inf))
+  freqs, S, grid, arrayType = prepareSystemMatrix(params.reco)
+  return SinglePatchReconstructionAlgorithm(params, params.reco.sf, S, arrayType, grid, freqs, Channel{Any}(Inf))
 end
 recoAlgorithmTypes(::Type{SinglePatchReconstruction}) = SystemMatrixBasedAlgorithm()
 AbstractImageReconstruction.parameter(algo::SinglePatchReconstructionAlgorithm) = algo.params
 
 function prepareSystemMatrix(reco::SinglePatchReconstructionParameter{L,S}) where {L<:AbstractSystemMatrixLoadingParameter, S<:AbstractLinearSolver}
   freqs, sf, grid = process(AbstractMPIRecoAlgorithm, reco.sfLoad, reco.sf)
-  sf, grid = prepareSF(S, sf, grid) 
-  return freqs, sf, grid
+  sf, grid = process(AbstractMPIRecoAlgorithm, reco.sfLoad, S, sf, grid, reco.arrayType)
+  return freqs, sf, grid, reco.arrayType
 end
 
 
@@ -44,13 +46,13 @@ function process(algo::SinglePatchReconstructionAlgorithm, params::Union{A, Proc
     @warn "System matrix and measurement have different element data type. Mapping measurment data to system matrix element type."
     result = map(eltype(algo.S),result)
   end
-  result = copyto!(similar(algo.S, size(result)...), result)
+  result = adapt(algo.arrayType, result)
   return result
 end
 
 
 function process(algo::SinglePatchReconstructionAlgorithm, params::SinglePatchReconstructionParameter, u)
-  weights = process(algo, params.weightingParams, u)
+  weights = adapt(algo.arrayType, process(algo, params.weightingParams, u))
 
   B = getLinearOperator(algo, params)
 
@@ -68,5 +70,5 @@ function getLinearOperator(algo::SinglePatchReconstructionAlgorithm, params::Sin
 end
 
 function getLinearOperator(algo::SinglePatchReconstructionAlgorithm, params::SinglePatchReconstructionParameter{<:SparseSystemMatrixLoadingParameter, S}) where {S}
-  return process(algo, params.sfLoad, eltype(algo.S), tuple(shape(algo.grid)...))
+  return process(algo, params.sfLoad, eltype(algo.S), algo.arrayType, tuple(shape(algo.grid)...))
 end

--- a/src/Algorithms/SinglePatchAlgorithms/SinglePatchTemporalRegularizationAlgorithm.jl
+++ b/src/Algorithms/SinglePatchAlgorithms/SinglePatchTemporalRegularizationAlgorithm.jl
@@ -1,9 +1,10 @@
 export SinglePatchTemporalRegularizationAlgorithm, SinglePatchTemporalRegularizationReconstructionParameter
 Base.@kwdef struct SinglePatchTemporalRegularizationReconstructionParameter{L<:DenseSystemMatixLoadingParameter,
-  SP<:AbstractSolverParameters} <: AbstractSinglePatchReconstructionParameters
+  SP<:AbstractSolverParameters, matT <: AbstractArray} <: AbstractSinglePatchReconstructionParameters
   # File
   sf::MPIFile
   sfLoad::Union{L, ProcessResultCache{L}}
+  arrayType::Type{matT} = Array
   # Solver
   solverParams::SP
   λ::Float32
@@ -14,10 +15,11 @@ Base.@kwdef struct SinglePatchTemporalRegularizationReconstructionParameter{L<:D
   bgDict::BGDictParameter
 end
 
-Base.@kwdef mutable struct SinglePatchTemporalRegularizationAlgorithm{P} <: AbstractSinglePatchReconstructionAlgorithm where {P<:AbstractSinglePatchAlgorithmParameters}
+Base.@kwdef mutable struct SinglePatchTemporalRegularizationAlgorithm{P, matT <: AbstractArray} <: AbstractSinglePatchReconstructionAlgorithm where {P<:AbstractSinglePatchAlgorithmParameters}
   params::P
   sf::Union{MPIFile,Vector{MPIFile}}
   S::AbstractArray
+  arrayType::Type{matT}
   bgDict::AbstractArray
   idxFG::Union{Nothing, UnitRange{Int64}, Vector{Int64}} = nothing
   idxFG::Union{Nothing, UnitRange{Int64}, Vector{Int64}} = nothing
@@ -30,8 +32,8 @@ function SinglePatchReconstruction(params::SinglePatchParameters{<:AbstractMPIPr
   return SinglePatchTemporalRegularizationAlgorithm(params)
 end
 function SinglePatchTemporalRegularizationAlgorithm(params::SinglePatchParameters{<:AbstractMPIPreProcessingParameters,R,PT}) where {R<:SinglePatchTemporalRegularizationReconstructionParameter,PT<:AbstractMPIPostProcessingParameters}
-  freqs, S, grid = prepareSystemMatrix(params.reco)
-  return SinglePatchTemporalRegularizationAlgorithm(params, params.reco.sf, S, process(SinglePatchTemporalRegularizationAlgorithm, params.reco.bgDict, freqs)
+  freqs, S, grid, arrayType = prepareSystemMatrix(params.reco)
+  return SinglePatchTemporalRegularizationAlgorithm(params, params.reco.sf, S, arrayType, process(SinglePatchTemporalRegularizationAlgorithm, params.reco.bgDict, freqs)
     ,params.reco.idxFG, params.reco.idxBG, grid, freqs, Channel{Any}(Inf))
 end
 recoAlgorithmTypes(::Type{SinglePatchTemporalRegularizationAlgorithm}) = SystemMatrixBasedAlgorithm()
@@ -39,8 +41,8 @@ AbstractImageReconstruction.parameter(algo::SinglePatchTemporalRegularizationAlg
 
 function prepareSystemMatrix(reco::SinglePatchTemporalRegularizationReconstructionParameter{L}) where {L<:AbstractSystemMatrixLoadingParameter}
   freqs, sf, grid = process(AbstractMPIRecoAlgorithm, reco.sfLoad, reco.sf)
-  sf, grid = prepareSF(Kaczmarz, sf, grid)
-  return freqs, sf, grid
+  sf, grid = process(AbstractMPIRecoAlgorithm, reco.sfLoad, Kaczmarz, sf, grid, reco.arrayType)
+  return freqs, sf, grid, reco.arrayType
 end
 
 AbstractImageReconstruction.take!(algo::SinglePatchTemporalRegularizationAlgorithm) = Base.take!(algo.output)
@@ -51,6 +53,7 @@ function process(algo::SinglePatchTemporalRegularizationAlgorithm, params::Abstr
     @warn "System matrix and measurement have different element data type. Mapping measurment data to system matrix element type."
     result = map(eltype(algo.S), result)
   end
+  result = adapt(algo.arrayType, result)
   return result
 end
 

--- a/src/LeastSquares.jl
+++ b/src/LeastSquares.jl
@@ -27,7 +27,7 @@ Base.@kwdef struct ConstraintMaskedSolverParameters{S, P<:AbstractSolverParamete
 end
 export ElaborateSolverParameters
 Base.@kwdef mutable struct ElaborateSolverParameters{SL} <: AbstractSolverParameters{SL}
-  solver::Type{SL}
+  solver::Type{SL} = Kaczmarz
   iterations::Int64 = 10
   enforceReal::Bool = true
   enforcePositive::Bool = true

--- a/src/MPIReco.jl
+++ b/src/MPIReco.jl
@@ -1,6 +1,7 @@
 module MPIReco
   using Reexport
   @reexport using RegularizedLeastSquares
+  using RegularizedLeastSquares.LinearOperators
   @reexport using ImageUtils
   @reexport using MPIFiles
   const shape = MPIFiles.shape

--- a/src/MPIReco.jl
+++ b/src/MPIReco.jl
@@ -5,6 +5,7 @@ module MPIReco
   @reexport using MPIFiles
   const shape = MPIFiles.shape
   using AbstractImageReconstruction
+  using Adapt
   @reexport using DSP
   using ProgressMeter
   using Unitful

--- a/src/MultiPatch.jl
+++ b/src/MultiPatch.jl
@@ -479,7 +479,6 @@ function getindex(op::MultiPatchOperator, i, j)
 end
 
 function LinearAlgebra.mul!(b::AbstractVector{T}, op::MultiPatchOperator{T}, x::AbstractVector{T}) where T
-  b[:] .= zero(T)
   for i in 1:size(op, 1)
     b[i] = dot_with_matrix_row(op, x, i)
   end

--- a/src/MultiPatch.jl
+++ b/src/MultiPatch.jl
@@ -222,7 +222,7 @@ function MultiPatchOperatorExpliciteMapping(SFs::MultiMPIFile, freq; bgCorrectio
 		                gridsize = hcat(calibSize.(SFs)...),
                     fov = hcat(calibFov.(SFs)...),
                     grid = nothing,
-		                tfCorrection = true,
+		                tfCorrection = rxHasTransferFunction(SFs),
 		                kargs...)
 
                     

--- a/src/MultiPatch.jl
+++ b/src/MultiPatch.jl
@@ -495,6 +495,26 @@ function LinearAlgebra.mul!(b::AbstractVector{T}, op::MultiPatchOperator{T}, x::
   return b
 end
 
+function LinearAlgebra.mul!(res::AbstractVector{T}, adj::Adjoint{T, OP}, t::AbstractVector{T}) where {T, V <: AbstractArray, OP <: MultiPatchOperator{T, V}}
+  op = adj.parent
+  res .= zero(T)
+
+  for i in 1:size(op, 1)
+    val = t[i]
+
+    p = op.RowToPatch[i]
+    xs = op.xss[p]
+    xc = op.xcc[p]
+    row = mod1(i,div(op.M,op.nPatches))
+    A = op.S[op.patchToSMIdx[p]]
+    sign = op.sign[row,op.patchToSMIdx[p]]
+  
+    for j in 1:length(xs)
+      res[xc[j]] += adjoint(sign*A[row,xs[j]]) * val
+    end
+  end
+  return res
+end
 
 ### The following is intended to use the standard kaczmarz method ###
 function RegularizedLeastSquares.normalize(norm::SystemMatrixBasedNormalization, op::MultiPatchOperator, b)

--- a/src/MultiPatch.jl
+++ b/src/MultiPatch.jl
@@ -468,14 +468,19 @@ size(FFOp::MultiPatchOperator) = (FFOp.M,FFOp.N)
 size(FFTOp::DenseMultiPatchOperator) = (FFTOp.M,FFTOp.N)
 
 length(FFOp::MultiPatchOperator) = size(FFOp,1)*size(FFOp,2)
-function getindex(op::MultiPatchOperator, i, j)
+function getindex(op::MultiPatchOperator, i::I, j::I) where I <: Integer
   p = op.RowToPatch[i]
   xs = op.xss[p]
+  xc = op.xcc[p]
   row = mod1(i,div(op.M,op.nPatches))
   A = op.S[op.patchToSMIdx[p]]
-  sign = op.sign[j,op.patchToSMIdx[p]]
-  # TODO or zero
-  return sign*A[row,xs[j]]
+  sign = op.sign[row,op.patchToSMIdx[p]]
+  index = findfirst(isequal(j), xc)
+  if !isnothing(index)
+    return sign*A[row,xs[index]]
+  else
+    return zero(eltype(op))
+  end
 end
 
 function LinearAlgebra.mul!(b::AbstractVector{T}, op::MultiPatchOperator{T}, x::AbstractVector{T}) where T

--- a/src/SystemMatrix/SystemMatrix.jl
+++ b/src/SystemMatrix/SystemMatrix.jl
@@ -67,9 +67,7 @@ end
 function process(t::Type{<:AbstractMPIRecoAlgorithm}, params::DenseSystemMatixLoadingParameter, sf::MPIFile, frequencies::Vector{CartesianIndex{2}})
   S, grid = getSF(sf, frequencies, nothing; toKwargs(params)...)
   @info "Loading SM"
-  if !isa(S, params.arrayType)
-    S = params.arrayType(S)
-  end
+  S = adapt(params.arrayType, S)
   return S, grid
 end
 

--- a/test/MultiGradient.jl
+++ b/test/MultiGradient.jl
@@ -15,7 +15,7 @@ using MPIReco
   params[:recChannels] = 1:2
   params[:iterations] = 3
   params[:sf] = bSFs
-  params[:λ] = 0.003
+  params[:reg] = [L2Regularization(0.003)]
   params[:tfCorrection] = false
   params[:roundPatches] = false
 

--- a/test/MultiPatch.jl
+++ b/test/MultiPatch.jl
@@ -53,6 +53,7 @@ using MPIReco
   # flexible multi-patch reconstruction
   dirs = ["8.mdf", "9.mdf", "10.mdf", "11.mdf"]
   bSFs = MultiMPIFile(joinpath.(datadir, "calibrations", dirs))
+  params[:sf] = bSFs
   mapping = [1,2,3,4]
   freq = filterFrequencies(bSFs, SNRThresh=5, minFreq=80e3)
   S = [getSF(SF,freq,nothing,Kaczmarz, bgcorrection=false)[1] for SF in bSFs]

--- a/test/MultiPatch.jl
+++ b/test/MultiPatch.jl
@@ -22,7 +22,7 @@ using MPIReco
   params[:iterations] = 1
   params[:spectralLeakageCorrection] = false
   params[:sf] = bSF
-  params[:λ] = 0
+  params[:reg] = L2Regularization(0.0f0)
   params[:tfCorrection] = false
   c1 = reconstruct("MultiPatch", b; params...)
   @test axisnames(c1) == names

--- a/test/MultiPatch.jl
+++ b/test/MultiPatch.jl
@@ -22,8 +22,9 @@ using MPIReco
   params[:iterations] = 1
   params[:spectralLeakageCorrection] = false
   params[:sf] = bSF
-  params[:reg] = L2Regularization(0.0f0)
+  params[:reg] = [L2Regularization(0.0f0)]
   params[:tfCorrection] = false
+  params[:solver] = Kaczmarz
   c1 = reconstruct("MultiPatch", b; params...)
   @test axisnames(c1) == names
   @test axisvalues(c1) == values1

--- a/test/ReconstructionGPU.jl
+++ b/test/ReconstructionGPU.jl
@@ -1,5 +1,5 @@
 for arrayType in arrayTypes
-  @testset "Reconstruction $arrayType" begin
+  @testset "Single Patch Reconstruction: $arrayType" begin
     bSF = MPIFile(joinpath(datadir, "calibrations", "12.mdf"))
     b = MPIFile(joinpath(datadir, "measurements", "20211226_203916_MultiPatch", "1.mdf"))
     names = (:color, :x, :y, :z, :time)
@@ -22,12 +22,33 @@ for arrayType in arrayTypes
     params[:solver] = CGNR
   
     c1 = reconstruct("SinglePatch", b; params...)
-    @test axisnames(c1) == names
-    @test axisvalues(c1) == values
   
     c2 = reconstruct("SinglePatch", b; params..., arrayType = arrayType)
-    @test axisnames(c2) == names
-    @test axisvalues(c2) == values
+
+    @test isapprox(arraydata(c1), arraydata(c2))
+  end
+
+  @testset "Sparse Single Patch Reconstruction: $arrayType" begin
+    bSF = MPIFile(joinpath(datadir, "calibrations", "7.mdf"))
+    b = MPIFile(joinpath(datadir, "measurements","20211226_204612_Dice", "1.mdf"))
+    redFactor = 0.01
+  
+    params = Dict{Symbol, Any}()
+    params[:SNRThresh] = 2
+    params[:frames] = 1:100
+    params[:minFreq] = 80e3
+    params[:recChannels] = 1:2
+    params[:iterations] = 3
+    params[:spectralLeakageCorrection] = false
+    params[:sf] = bSF
+    params[:reg] = [L2Regularization(0.1f0)]
+    params[:numAverages] = 100
+    params[:solver] = CGNR
+    params[:redFactor] = redFactor
+  
+    c1 = reconstruct("SinglePatchSparse", b; params..., sparseTrafo = "FFT", useDFFoV = false)
+  
+    c2 = reconstruct("SinglePatchSparse", b; params..., sparseTrafo = "FFT", useDFFoV = false, arrayType = arrayType)
 
     @test isapprox(arraydata(c1), arraydata(c2))
   end

--- a/test/ReconstructionGPU.jl
+++ b/test/ReconstructionGPU.jl
@@ -22,10 +22,13 @@ for arrayType in arrayTypes
     params[:solver] = CGNR
   
     c1 = reconstruct("SinglePatch", b; params...)
-  
     c2 = reconstruct("SinglePatch", b; params..., arrayType = arrayType)
-
     @test isapprox(arraydata(c1), arraydata(c2))
+
+    params[:weightingParams] = WhiteningWeightingParameters(whiteningMeas = bSF)
+    c3 = reconstruct("SinglePatch", b; params...)
+    c4 = reconstruct("SinglePatch", b; params..., arrayType = arrayType)
+    @test isapprox(arraydata(c3), arraydata(c4))
   end
 
   @testset "Sparse Single Patch Reconstruction: $arrayType" begin
@@ -45,11 +48,60 @@ for arrayType in arrayTypes
     params[:numAverages] = 100
     params[:solver] = CGNR
     params[:redFactor] = redFactor
+    params[:sparseTrafo] = "FFT"
+    params[:useDFFoV] = false
   
-    c1 = reconstruct("SinglePatchSparse", b; params..., sparseTrafo = "FFT", useDFFoV = false)
-  
-    c2 = reconstruct("SinglePatchSparse", b; params..., sparseTrafo = "FFT", useDFFoV = false, arrayType = arrayType)
-
+    c1 = reconstruct("SinglePatchSparse", b; params...)
+    c2 = reconstruct("SinglePatchSparse", b; params..., arrayType = arrayType)
     @test isapprox(arraydata(c1), arraydata(c2))
+
+    params[:weightingParams] = WhiteningWeightingParameters(whiteningMeas = bSF)
+    c3 = reconstruct("SinglePatchSparse", b; params...)
+    c4 = reconstruct("SinglePatchSparse", b; params..., arrayType = arrayType)
+    @test isapprox(arraydata(c3), arraydata(c4))
   end
+
+  @testset "Multi Patch Reconstruction: $arrayType" begin
+    dirs = ["1.mdf", "2.mdf", "3.mdf", "4.mdf"]
+    b = MultiMPIFile(joinpath.(datadir, "measurements", "20211226_203916_MultiPatch", dirs))
+  
+    dirs = ["8.mdf", "9.mdf", "10.mdf", "11.mdf"]
+    bSFs = MultiMPIFile(joinpath.(datadir, "calibrations", dirs))
+
+  
+    mapping = [1,2,3,4]
+    freq = filterFrequencies(bSFs, SNRThresh=5, minFreq=80e3)
+    S = [getSF(SF,freq,nothing,Kaczmarz, bgcorrection=false)[1] for SF in bSFs]
+    SFGridCenter = zeros(3,4)
+  
+    FFPos = zeros(3,4)
+    FFPos[:,1] = [-0.008, 0.008, 0.0]
+    FFPos[:,2] = [-0.008, -0.008, 0.0]
+    FFPos[:,3] = [0.008, 0.008, 0.0]
+    FFPos[:,4] = [0.008, -0.008, 0.0]
+    ffPos = CustomFocusFieldPositions(FFPos)
+  
+
+    params = Dict{Symbol, Any}()
+    params[:SNRThresh] = 5
+    params[:frames] = [1]
+    params[:minFreq] = 80e3
+    params[:recChannels] = 1:2
+    params[:iterations] = 50
+    params[:spectralLeakageCorrection] = true
+    params[:sf] = bSFs
+    params[:reg] = [L2Regularization(0.0f0)]
+    params[:tfCorrection] = false
+    params[:solver] = CGNR
+
+    opParams = ExplicitMultiPatchParameter(;tfCorrection = false, systemMatrices = S, SFGridCenter = SFGridCenter, mapping = mapping)
+    params[:opParams] = opParams
+    params[:ffPos] = ffPos
+    params[:ffPosSF] = ffPos
+
+    c1 = reconstruct("MultiPatch", b; params...)
+    c2 = reconstruct("MultiPatch", b; params..., arrayType = arrayType)
+    @test isapprox(arraydata(c1), arraydata(c2), rtol = 0.02)
+  end
+
 end

--- a/test/ReconstructionGPU.jl
+++ b/test/ReconstructionGPU.jl
@@ -88,7 +88,7 @@ for arrayType in arrayTypes
     params[:minFreq] = 80e3
     params[:recChannels] = 1:2
     params[:iterations] = 50
-    params[:spectralLeakageCorrection] = true
+    params[:spectralLeakageCorrection] = false
     params[:sf] = bSFs
     params[:reg] = [L2Regularization(0.0f0)]
     params[:tfCorrection] = false
@@ -102,6 +102,25 @@ for arrayType in arrayTypes
     c1 = reconstruct("MultiPatch", b; params...)
     c2 = reconstruct("MultiPatch", b; params..., arrayType = arrayType)
     @test isapprox(arraydata(c1), arraydata(c2), rtol = 0.02)
+
+    # Test Kaczmarz since it uses specific functions and not just mul!
+    bSF = MultiMPIFile([joinpath(datadir, "calibrations", "12.mdf")])
+    dirs = ["1.mdf", "2.mdf", "3.mdf", "4.mdf"]
+    b = MultiMPIFile(joinpath.(datadir, "measurements", "20211226_203916_MultiPatch", dirs))  
+    params = Dict{Symbol, Any}()
+    params[:SNRThresh] = 5
+    params[:frames] = [1]
+    params[:minFreq] = 80e3
+    params[:recChannels] = 1:2
+    params[:iterations] = 1
+    params[:spectralLeakageCorrection] = false
+    params[:sf] = bSF
+    params[:reg] = [L2Regularization(0.0f0)]
+    params[:tfCorrection] = false
+    params[:solver] = Kaczmarz
+    c3 = reconstruct("MultiPatch", b; params...)
+    c4 = reconstruct("MultiPatch", b; params..., arrayType = arrayType)
+    @test isapprox(arraydata(c3), arraydata(c4))
   end
 
 end

--- a/test/SMExtrapolation.jl
+++ b/test/SMExtrapolation.jl
@@ -56,7 +56,7 @@ using MPIReco
     params[:iterations] = 1
     params[:spectralLeakageCorrection] = false
     params[:sf] = bSFs
-    params[:λ] = 0
+    params[:reg] = [L2Regularization(0.0f0)]
     params[:tfCorrection] = false
     c2 = reconstruct("MultiPatch", b; params...)
 


### PR DESCRIPTION
This PR aims to add further GPU support to MPIReco:

- [x] Use Adapt.jl to move things to the GPU
- [x] Weighting GPU support
- [x] Sparse Single Patch GPU support
- [x] Multi Patch GPU support
