### PR TITLE
Add composite freq. selection

### DIFF
--- a/src/PreProcessing/FrequencyFilterParameter.jl
+++ b/src/PreProcessing/FrequencyFilterParameter.jl
@@ -9,14 +9,16 @@ function process(::Type{<:AbstractMPIRecoAlgorithm}, params::NoFrequencyFilterPa
 end
 
 export DirectSelectionFrequencyFilterParameters
-Base.@kwdef struct DirectSelectionFrequencyFilterParameters{T <: Integer, FIT <: AbstractVector{T}} <: AbstractFrequencyFilterParameter
+Base.@kwdef struct DirectSelectionFrequencyFilterParameters{T <: Union{Integer, CartesianIndex{2}}, FIT <: AbstractVector{T}} <: AbstractFrequencyFilterParameter
   freqIndices::FIT
 end
-
-function process(::Type{<:AbstractMPIRecoAlgorithm}, params::DirectSelectionFrequencyFilterParameters, file::MPIFile)
+function process(::Type{<:AbstractMPIRecoAlgorithm}, params::DirectSelectionFrequencyFilterParameters{T}, file::MPIFile) where T <: Integer
   nFreq = params.freqIndices
   nReceivers = rxNumChannels(file)
-  return collect(vec(CartesianIndices((nFreq, nReceivers))))
+  return vec([CartesianIndex{2}(i, j) for i in nFreq, j in nReceivers])
+end
+function process(::Type{<:AbstractMPIRecoAlgorithm}, params::DirectSelectionFrequencyFilterParameters{T}, file::MPIFile) where T <: CartesianIndex{2}
+  return params.freqIndices
 end
 
 # Could possible also be nested

--- a/test/Reconstruction.jl
+++ b/test/Reconstruction.jl
@@ -160,4 +160,21 @@
   c11d = reconstruct("SinglePatch", b; params..., freqFilter = DirectSelectionFrequencyFilterParameters(freqIndices = freq_components))
   @test isapprox(arraydata(c11c), arraydata(c11d))
 
+  # No given freqs should be same as normal SNR thresh
+  freqFilter = CompositeFrequencyFilterParameters([
+    DirectSelectionFrequencyFilterParameters(),
+    SNRThresholdFrequencyFilterParameter(minFreq = params[:minFreq], SNRThresh = params[:SNRThresh], recChannels = params[:recChannels])
+  ])
+  c11e = reconstruct("SinglePatch", b; params..., freqFilter = freqFilter)
+  @test isapprox(arraydata(c11a), arraydata(c11e))
+
+  # Custom freqs should remove one channel
+  custom_freqs = filter(f -> f[2] == 2, freqs)
+  freqFilter = CompositeFrequencyFilterParameters([
+    DirectSelectionFrequencyFilterParameters(freqIndices = custom_freqs),
+    SNRThresholdFrequencyFilterParameter(minFreq = params[:minFreq], SNRThresh = params[:SNRThresh], recChannels = params[:recChannels])
+  ])
+  c11f = reconstruct("SinglePatch", b; params..., freqFilter = freqFilter)
+  c11g = reconstruct("SinglePatch", b; params..., recChannels = 2:2)
+  @test isapprox(arraydata(c11f), arraydata(c11g))
 end


### PR DESCRIPTION
This PR adds a composite freq. selection which allows a user to specify multiple frequency filters.

It also allows a user to directly give CartiesnIndices with the DirectSelectionFrequencyFilterParameters (additionally to the usual freq. integer components)