### PR TITLE
Fix reco grid for mismatching gradients

### DIFF
--- a/src/Algorithms/SinglePatchAlgorithms/SinglePatchAlgorithms.jl
+++ b/src/Algorithms/SinglePatchAlgorithms/SinglePatchAlgorithms.jl
@@ -31,8 +31,7 @@ function AbstractImageReconstruction.put!(algo::AbstractSinglePatchReconstructio
 end
 
 function finalizeResult(algo::AbstractSinglePatchReconstructionAlgorithm, result, data::MPIFile)
-  pixspacing = (spacing(algo.grid) ./ acqGradient(data)[1] .* acqGradient(algo.sf)[1])*1000u"mm"
-  offset = (ffPos(data) .- 0.5 .* calibFov(algo.sf))*1000u"mm" .+ 0.5 .* pixspacing
+  pixspacing, offset = calcSpacingAndOffset(algo.sf, data, algo.grid)
   dt = acqNumAverages(data)*dfCycle(data)*numAverages(algo.params.pre)*1u"s"
   im = makeAxisArray(result, pixspacing, offset, dt)
   return ImageMeta(im, generateHeaderDict(algo.sf, data))

--- a/src/Reconstruction.jl
+++ b/src/Reconstruction.jl
@@ -322,8 +322,7 @@ function initImage(bSFs::Union{T,Vector{T}}, bMeas::S, L::Int, numAverages::Int,
   end
   # calculate axis
   shp = shape(grid)
-  pixspacing = (spacing(grid) ./ acqGradient(bMeas)[1] .* acqGradient(bSF)[1])*1000u"mm"
-  offset = (ffPos(bMeas) .- 0.5 .* calibFov(bSF))*1000u"mm" .+ 0.5 .* pixspacing
+  pixspacing, offset = calcSpacingAndOffset(bSF, bMeas, grid)
   dtframes = acqNumAverages(bMeas)*dfCycle(bMeas)*numAverages*1u"s"
   # initialize raw array
   array = Array{Float32}(undef, numcolors,shp...,L)

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -228,3 +228,11 @@ function constraint!(x, enforcePositive, enforceReal)
 end
 
 softThreshold(x,sigma) = (abs(x) > sigma)*sign(x)*(abs(x)-sigma)
+
+function calcSpacingAndOffset(sf::MPIFile, data::MPIFile, grid)
+  gradientRatio = acqGradient(sf)[1] / acqGradient(data)[1]
+  pixspacing = (spacing(grid) * gradientRatio) * 1000u"mm"
+  fov = round.(calibFov(sf), digits=9) # everything below nm is a numerical error
+  offset = (ffPos(data) .- 0.5fov) * gradientRatio * 1000u"mm" .+ 0.5pixspacing
+  return pixspacing, offset
+end


### PR DESCRIPTION
When doing a hybrid reconstruction with two mismatching gradients (both magnitude and sign) we noticed that the grid calculation is off.

The main change apart from moving the calculation to a separate function is that the offset is now also scaled by the ratio of the gradients. This even works for gradients with different sign, resulting in an axis like 10:-1:-10 resulting in correctly oriented images after plotting with the axes (at least when using Makie)