### PR TITLE
Add tfCorrection parameter

### DIFF
--- a/src/Background.jl
+++ b/src/Background.jl
@@ -16,6 +16,7 @@ Base.@kwdef struct ExternalPreProcessedBackgroundCorrectionParameters{T} <: Abst
   numPeriodGrouping::Int64 = 1
   spectralLeakageCorrection::Bool = false
   loadasreal::Bool = false
+  tfCorrection::Union{Bool, Nothing} = nothing
   bgParams::T
 end
 # TODO Shorter struct names?
@@ -24,7 +25,6 @@ export SimpleExternalBackgroundCorrectionParameters
 Base.@kwdef struct SimpleExternalBackgroundCorrectionParameters <: ExternalBackgroundCorrection
   emptyMeas::MPIFile
   bgFrames::Union{Vector{Int64}, UnitRange{Int64}} = [1]
-  tfCorrection::Bool = false
 end
 function process(::Type{<:AbstractMPIRecoAlgorithm}, params::SimpleExternalBackgroundCorrectionParameters, data::Array)
   kwargs = toKwargs(params, overwrite = Dict{Symbol, Any}(:frames => params.bgFrames))
@@ -32,7 +32,8 @@ function process(::Type{<:AbstractMPIRecoAlgorithm}, params::SimpleExternalBackg
   return data .-empty
 end
 function process(::Type{<:AbstractMPIRecoAlgorithm}, params::ExternalPreProcessedBackgroundCorrectionParameters{SimpleExternalBackgroundCorrectionParameters}, data::Array, frequencies::Union{Vector{CartesianIndex{2}}, Nothing} = nothing)
-  kwargs = toKwargs(params, overwrite = Dict{Symbol, Any}(:frames => params.bgParams.bgFrames), ignore = [:bgParams])
+  kwargs = toKwargs(params, default = Dict{Symbol, Any}(:tfCorrection => rxHasTransferFunction(params.bgParams.emptyMeas)),
+                    overwrite = Dict{Symbol, Any}(:frames => params.bgParams.bgFrames), ignore = [:bgParams])
   empty = getMeasurementsFD(params.bgParams.emptyMeas, false; bgCorrection = false, numAverages=length(params.bgParams.bgFrames), kwargs..., frequencies = frequencies)
   return data .-empty
 end
@@ -42,7 +43,6 @@ Base.@kwdef struct LinearInterpolatedExternalBackgroundCorrectionParameters <: A
   emptyMeas::MPIFile
   bgFrames::UnitRange{Int64} = 1:1
   bgFramesPost::UnitRange{Int64} = 1:1
-  tfCorrection::Bool = false
 end
 function process(::Type{<:AbstractMPIRecoAlgorithm}, params::LinearInterpolatedExternalBackgroundCorrectionParameters, data::Array)
   kwargs = toKwargs(params)
@@ -57,8 +57,8 @@ function process(::Type{<:AbstractMPIRecoAlgorithm}, params::LinearInterpolatedE
   return result
 end
 function process(::Type{<:AbstractMPIRecoAlgorithm}, params::ExternalPreProcessedBackgroundCorrectionParameters{LinearInterpolatedExternalBackgroundCorrectionParameters}, data::Array, frequencies::Union{Vector{CartesianIndex{2}}, Nothing} = nothing)
-  kwargs = toKwargs(params, ignore = [:bgParams])
   bgParams = params.bgParams
+  kwargs = toKwargs(params, default = Dict{Symbol, Any}(:tfCorrection => rxHasTransferFunction(bgParams.emptyMeas)), ignore = [:bgParams])
   kwargs[:frames] = bgParams.bgFrames
   empty = getMeasurementsFD(bgParams.emptyMeas, false; bgCorrection = false, numAverages=length(bgParams.bgFrames), kwargs..., frequencies = frequencies)
   kwargs[:frames] = bgParams.bgFramesPost

--- a/src/Background.jl
+++ b/src/Background.jl
@@ -24,6 +24,7 @@ export SimpleExternalBackgroundCorrectionParameters
 Base.@kwdef struct SimpleExternalBackgroundCorrectionParameters <: ExternalBackgroundCorrection
   emptyMeas::MPIFile
   bgFrames::Union{Vector{Int64}, UnitRange{Int64}} = [1]
+  tfCorrection::Bool = false
 end
 function process(::Type{<:AbstractMPIRecoAlgorithm}, params::SimpleExternalBackgroundCorrectionParameters, data::Array)
   kwargs = toKwargs(params, overwrite = Dict{Symbol, Any}(:frames => params.bgFrames))
@@ -41,6 +42,7 @@ Base.@kwdef struct LinearInterpolatedExternalBackgroundCorrectionParameters <: A
   emptyMeas::MPIFile
   bgFrames::UnitRange{Int64} = 1:1
   bgFramesPost::UnitRange{Int64} = 1:1
+  tfCorrection::Bool = false
 end
 function process(::Type{<:AbstractMPIRecoAlgorithm}, params::LinearInterpolatedExternalBackgroundCorrectionParameters, data::Array)
   kwargs = toKwargs(params)

--- a/src/PreProcessing/CommonPreProcessing.jl
+++ b/src/PreProcessing/CommonPreProcessing.jl
@@ -10,8 +10,8 @@ Base.@kwdef struct CommonPreProcessingParameters{T<:AbstractMPIBackgroundCorrect
   bgParams::T = NoBackgroundCorrectionParameters()
   "Frames to be retrieved from the data"
   frames::Union{Nothing, UnitRange{Int64}, Vector{Int64}} = nothing
-  "If measurement should be corrected with a transfer function"
-  tfCorrection::Bool = false
+  "If measurement should be corrected with a transfer function. Default behaviour (nothing) is `rxHasTransferFunction`"
+  tfCorrection::Union{Bool, Nothing} = nothing
   "If background frames should be neglected in frame index selection"
   neglectBGFrames::Bool = true
   "Number of frames that should be averaged together"
@@ -27,17 +27,20 @@ Base.@kwdef struct CommonPreProcessingParameters{T<:AbstractMPIBackgroundCorrect
 end
 
 function process(t::Type{<:AbstractMPIRecoAlgorithm}, params::CommonPreProcessingParameters{NoBackgroundCorrectionParameters}, f::MPIFile, frequencies::Union{Vector{CartesianIndex{2}}, Nothing} = nothing)
-  kwargs = toKwargs(params, default = Dict{Symbol, Any}(:frames => params.neglectBGFrames ? (1:acqNumFGFrames(f)) : (1:acqNumFrames(f))), ignore = [:neglectBGFrames, :bgParams])
+  kwargs = toKwargs(params, default = Dict{Symbol, Any}(:tfCorrection => rxHasTransferFunction(f),
+                    :frames => params.neglectBGFrames ? (1:acqNumFGFrames(f)) : (1:acqNumFrames(f))), ignore = [:neglectBGFrames, :bgParams])
   result = getMeasurementsFD(f; bgCorrection = false, kwargs..., frequencies = frequencies)
   return result
 end
 function process(t::Type{<:AbstractMPIRecoAlgorithm}, params::CommonPreProcessingParameters{InternalBackgroundCorrectionParameters}, f::MPIFile, frequencies::Union{Vector{CartesianIndex{2}}, Nothing} = nothing)
-  kwargs = toKwargs(params, default = Dict{Symbol, Any}(:frames => params.neglectBGFrames ? (1:acqNumFGFrames(f)) : (1:acqNumFrames(f))), ignore = [:neglectBGFrames, :bgParams])
+  kwargs = toKwargs(params, default = Dict{Symbol, Any}(:tfCorrection => rxHasTransferFunction(f),
+                    :frames => params.neglectBGFrames ? (1:acqNumFGFrames(f)) : (1:acqNumFrames(f))), ignore = [:neglectBGFrames, :bgParams])
   result = getMeasurementsFD(f; bgCorrection = true, interpolateBG = params.bgParams.interpolateBG, kwargs..., frequencies = frequencies)
   return result
 end
 function process(t::Type{<:AbstractMPIRecoAlgorithm}, params::CommonPreProcessingParameters{<:ExternalBackgroundCorrection}, f::MPIFile, frequencies::Union{Vector{CartesianIndex{2}}, Nothing} = nothing)
-  kwargs = toKwargs(params, default = Dict{Symbol, Any}(:frames => params.neglectBGFrames ? (1:acqNumFGFrames(f)) : (1:acqNumFrames(f))), ignore = [:neglectBGFrames, :bgParams])
+  kwargs = toKwargs(params, default = Dict{Symbol, Any}(:tfCorrection => rxHasTransferFunction(f),
+                    :frames => params.neglectBGFrames ? (1:acqNumFGFrames(f)) : (1:acqNumFrames(f))), ignore = [:neglectBGFrames, :bgParams])
   result = getMeasurementsFD(f; bgCorrection = false, kwargs..., frequencies = frequencies)
   bgParams = fromKwargs(ExternalPreProcessedBackgroundCorrectionParameters; kwargs..., bgParams = params.bgParams, frequencies = frequencies)
   return process(t, bgParams, result, frequencies)

--- a/src/PreProcessing/CommonPreProcessing.jl
+++ b/src/PreProcessing/CommonPreProcessing.jl
@@ -10,6 +10,8 @@ Base.@kwdef struct CommonPreProcessingParameters{T<:AbstractMPIBackgroundCorrect
   bgParams::T = NoBackgroundCorrectionParameters()
   "Frames to be retrieved from the data"
   frames::Union{Nothing, UnitRange{Int64}, Vector{Int64}} = nothing
+  "If measurement should be corrected with a transfer function"
+  tfCorrection::Bool = false
   "If background frames should be neglected in frame index selection"
   neglectBGFrames::Bool = true
   "Number of frames that should be averaged together"

--- a/src/SystemMatrix/SystemMatrix.jl
+++ b/src/SystemMatrix/SystemMatrix.jl
@@ -30,7 +30,9 @@ SystemMatrixGriddingParameter(file::MPIFile) = SystemMatrixGriddingParameter(
   center = calibFovCenter(file)
 )
 
-export defaultParameterGridSize, defaultParameterCalibCenter, defaultParameterCalibFov
+export defaultParameterTfCorrection, defaultParameterGridSize, defaultParameterCalibCenter, defaultParameterCalibFov
+defaultParameterTfCorrection(new::MPIFile) = rxHasTransferFunction(new)
+defaultParameterTfCorrection(new::Missing) = missing
 defaultParameterGridSize(new::MPIFile) = gridSizeCommon(new)
 defaultParameterGridSize(new::Missing) = missing
 defaultParameterCalibCenter(new::MPIFile) = calibFovCenter(new)
@@ -56,6 +58,7 @@ Base.@kwdef struct DenseSystemMatixLoadingParameter{F<:AbstractFrequencyFilterPa
   freqFilter::F
   gridding::G
   bgCorrection::Bool = false
+  tfCorrection::Bool = false
   loadasreal::Bool = false
 end
 function process(t::Type{<:AbstractMPIRecoAlgorithm}, params::DenseSystemMatixLoadingParameter, sf::MPIFile)
@@ -76,6 +79,7 @@ Base.@kwdef struct SparseSystemMatrixLoadingParameter{F<:AbstractFrequencyFilter
   thresh::Float64 = 0.0
   redFactor::Float64 = 0.1
   bgCorrection::Bool = false
+  tfCorrection::Bool = false
   loadasreal::Bool=false
   useDFFoV::Bool = false
 end

--- a/src/SystemMatrix/SystemMatrix.jl
+++ b/src/SystemMatrix/SystemMatrix.jl
@@ -58,7 +58,7 @@ Base.@kwdef struct DenseSystemMatixLoadingParameter{F<:AbstractFrequencyFilterPa
   freqFilter::F
   gridding::G
   bgCorrection::Bool = false
-  tfCorrection::Bool = false
+  tfCorrection::Union{Bool, Nothing} = nothing
   loadasreal::Bool = false
 end
 function process(t::Type{<:AbstractMPIRecoAlgorithm}, params::DenseSystemMatixLoadingParameter, sf::MPIFile)
@@ -67,7 +67,7 @@ function process(t::Type{<:AbstractMPIRecoAlgorithm}, params::DenseSystemMatixLo
   return frequencies, process(t, params, sf, frequencies)...
 end
 function process(t::Type{<:AbstractMPIRecoAlgorithm}, params::DenseSystemMatixLoadingParameter, sf::MPIFile, frequencies::Vector{CartesianIndex{2}})
-  S, grid = getSF(sf, frequencies, nothing; toKwargs(params)...)
+  S, grid = getSF(sf, frequencies, nothing; toKwargs(params, default = Dict{Symbol, Any}(:tfCorrection => rxHasTransferFunction(sf)))...)
   @info "Loading SM"
   return S, grid
 end
@@ -79,7 +79,7 @@ Base.@kwdef struct SparseSystemMatrixLoadingParameter{F<:AbstractFrequencyFilter
   thresh::Float64 = 0.0
   redFactor::Float64 = 0.1
   bgCorrection::Bool = false
-  tfCorrection::Bool = false
+  tfCorrection::Union{Bool, Nothing} = nothing
   loadasreal::Bool=false
   useDFFoV::Bool = false
 end
@@ -89,7 +89,7 @@ function process(t::Type{<:AbstractMPIRecoAlgorithm}, params::SparseSystemMatrix
   return frequencies, process(t, params, sf, frequencies)...
 end
 function process(t::Type{<:AbstractMPIRecoAlgorithm}, params::SparseSystemMatrixLoadingParameter, sf::MPIFile, frequencies::Vector{CartesianIndex{2}})
-  S, grid = getSF(sf, frequencies, params.sparseTrafo; toKwargs(params)...)
+  S, grid = getSF(sf, frequencies, params.sparseTrafo; toKwargs(params, default = Dict{Symbol, Any}(:tfCorrection => rxHasTransferFunction(sf)))...)
   return S, grid
 end
 function process(t::Type{<:AbstractMPIRecoAlgorithm}, params::SparseSystemMatrixLoadingParameter, elType::Type{<:Number}, arrayType, shape::NTuple{N, Int64}) where N

--- a/src/Weighting.jl
+++ b/src/Weighting.jl
@@ -30,10 +30,11 @@ process(::Type{<:AbstractMPIRecoAlgorithm}, params::ChannelWeightingParameters, 
 export WhiteningWeightingParameters
 Base.@kwdef struct WhiteningWeightingParameters <: AbstractWeightingParameters
   whiteningMeas::MPIFile
-  tfCorrection::Bool = false
+  tfCorrection::Union{Bool, Nothing} = nothing
 end
 function process(::Type{<:AbstractMPIRecoAlgorithm}, params::WhiteningWeightingParameters, freqs::Vector{CartesianIndex{2}}, args...)
-  u_bg = getMeasurementsFD(params.whiteningMeas, false, frequencies=freqs, frames=measBGFrameIdx(params.whiteningMeas), bgCorrection = false, tfCorrection=false)
+  u_bg = getMeasurementsFD(params.whiteningMeas, false, tfCorrection = isnothing(params.tfCorrection) ? rxHasTransferFunction(params.whiteningMeas) : params.tfCorrection, 
+                           frequencies=freqs, frames=measBGFrameIdx(params.whiteningMeas), bgCorrection = false)
   bg_std = std(u_bg, dims=3)
   weights = minimum(abs.(vec(bg_std))) ./ abs.(vec(bg_std))
   return weights


### PR DESCRIPTION
Closes #68. This could be seen as a breaking change.

Previously tfCorrection was just the default from MPIFiles, which usually was rxHasTransferfunction. Because certain structs didn't have this parameter, we couldn't change that behaviour in certain cases anymore (this is a regression).

We now have three options:

- Default to true or false (I chose false for now) for all tfCorrections
- Default to rxHasTransferfunction of the system matrix
- Default to missing + add aditional logic that ignores tfCorrection if the parameter is missing. This would replicate the old behaviour in cases where the user specified nothing

What are everyones preferences @tknopp, @jusack, @jonschumacher, @mboberg?