### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,8 +4,7 @@ steps:
       - JuliaCI/julia#v1:
           version: "1.10"
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     command: |
       julia --color=yes --project -e '
       using Pkg
@@ -17,22 +16,21 @@ steps:
       include("test/gpu/cuda.jl")'
     timeout_in_minutes: 30
 
-   - label: "AMD GPUs -- MPIReco.jl"
-     plugins:
-       - JuliaCI/julia#v1:
-           version: "1.10"
-     agents:
-       queue: "juliagpu"
-       rocm: "*"
-       rocmgpu: "*"
-     command: |
-       julia --color=yes --project -e '
-       using Pkg
-       Pkg.add("TestEnv")
-       using TestEnv
-       TestEnv.activate();
-       Pkg.add("AMDGPU")
-       Pkg.instantiate()
-       include("test/gpu/rocm.jl")'
-     timeout_in_minutes: 30
-     soft_fail: true
+  - label: "AMD GPUs -- MPIReco.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.10"
+    agents:
+      queue: "rocm"
+      rocmgpu: "*"
+    command: |
+      julia --color=yes --project -e '
+      using Pkg
+      Pkg.add("TestEnv")
+      using TestEnv
+      TestEnv.activate();
+      Pkg.add("AMDGPU")
+      Pkg.instantiate()
+      include("test/gpu/rocm.jl")'
+    timeout_in_minutes: 30
+    soft_fail: true


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag.

This change only affects agent selection; the steps themselves are unchanged. The AMD GPU step was also re-indented: it was previously indented one extra space, which made the file invalid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)